### PR TITLE
Enable hyperlink navigation in customize preview

### DIFF
--- a/src/wp-admin/js/customize-controls.js
+++ b/src/wp-admin/js/customize-controls.js
@@ -34,6 +34,8 @@ document.addEventListener( 'DOMContentLoaded', function() {
 		hash = window.location.hash.replace( '#', '' ),
 		section = document.getElementById( 'sub-accordion-section-custom_css' );
 
+	const iframe = document.querySelector( '#customize-preview iframe' );
+
 	// Go direct to appropriate Customizer panel if its hash is specified in the URL
 	if ( hash === 'menu-to-edit' ) {
 		hash = 'sub-accordion-panel-nav_menus';
@@ -1941,4 +1943,45 @@ document.addEventListener( 'DOMContentLoaded', function() {
 
 		document.querySelector( '.displaying-num' ).textContent = items.length + ' ' + num[1];
 	}
+
+	/**
+	 * Enable navigation in the preview pane via hyperlinks.
+	 */
+	iframe.addEventListener( 'load', function () {
+		try {
+			const iframeDoc = iframe.contentDocument || iframe.contentWindow.document;
+
+			iframeDoc.addEventListener( 'click', function ( e ) {
+				const anchor = e.target.closest( 'a' );
+				if ( ! anchor ) {
+					return;
+				}
+
+				const href = anchor.getAttribute( 'href' );
+				if ( ! href || href.startsWith( '#' ) || href.startsWith( 'javascript:' ) ) {
+					return;
+				}
+
+				// Resolve to absolute URL.
+				const url = new URL( href, iframeDoc.baseURI );
+
+				// Only follow same-origin links in the preview.
+				if ( url.origin !== window.location.origin ) {
+					return;
+				}
+
+				e.preventDefault();
+
+				// Preserve the customizer messenger params.
+			    url.searchParams.set( 'customize_changeset_uuid', iframe.src.match( /customize_changeset_uuid=([^&]+)/ )?.[1] ?? '' );
+				url.searchParams.set( 'customize_theme', iframe.src.match( /customize_theme=([^&]+)/ )?.[1] ?? '' );
+				url.searchParams.set( 'customize_messenger_channel', 'preview-0' );
+
+				iframe.src = url.toString();
+			} );
+		} catch ( err ) {
+			// Cross-origin guard, just in case
+			console.warn( '[Customizer] Could not attach preview link handler:', err );
+		}
+	} );
 } );


### PR DESCRIPTION
This PR makes hyperlinks within the Customizer live preview pane functional. In other words, clicking on (say) a menu item in the preview pane will take the user to a preview of that page. This enables the Customizer to be used as a way of previewing a whole site and not just its home page.